### PR TITLE
Ccdc 2021 api updates

### DIFF
--- a/docs/_sources/tutorial.txt
+++ b/docs/_sources/tutorial.txt
@@ -71,7 +71,7 @@ Create conda environment using the environment.yml:
 
 .. code-block:: shell
 
-    conda create -n hotspots -f environment.yml
+    conda env create -n hotspots --file environment.yml
 
 Finally, there are a few environment variables to set:
 

--- a/docsrc/tutorial.txt
+++ b/docsrc/tutorial.txt
@@ -71,7 +71,7 @@ Create conda environment using the environment.yml:
 
 .. code-block:: shell
 
-    conda create -n hotspots -f environment.yml
+    conda env create -n hotspots --file environment.yml
 
 Finally, there are a few environment variables to set:
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,8 @@
 # Minimal Environment
 channels:
-- file://local/pcurran/CCDC/Python_API_2020/ccdc_conda_channel   # edit as needed
+- file://local/pcurran/CCDC/Python_API_2020/ccdc_conda_channel  # edit as needed
+## For example, with a standard CCDC 2020 install on Windows 10 this might be as below for the CCDC miniconda installation
+## - file://\Program Files\CCDC\Python_API_2020\ccdc_conda_channel # edit as needed
 - rdkit
 - bioconda
 - conda-forge
@@ -28,6 +30,7 @@ dependencies:
 - conda-forge::tqdm
 - conda-forge::xmltodict
 - conda-forge::hdbscan
-- schrodinger:: pymol
+# If you want pymol extensions to work you will need this 
+# - schrodinger:: pymol
 - anaconda::biopython       # only for arpeggio related things
 

--- a/hotspots/__init__.py
+++ b/hotspots/__init__.py
@@ -1,3 +1,13 @@
+# Unfortunately RDKit and matplotlib are both linked to specific underlying 
+# versions of compiled libraries. The CCDC code is less fussy, but this means if
+# these modules are imported after CCDC modules the imports of rdkit & matplolib 
+# can fail depending on the exact version of the underlying library pulled in
+# if it happens the version the CCDC import pulled in was one that they dont work with.
+#
+from rdkit import *
+from rdkit.Chem.rdmolops import *
+from matplotlib import *
+
 from hotspots import calculation
 
 

--- a/hotspots/calculation.py
+++ b/hotspots/calculation.py
@@ -28,16 +28,23 @@ from os.path import join
 
 import numpy as np
 import pkg_resources
-from ccdc.cavity import Cavity
-from ccdc.io import MoleculeWriter, MoleculeReader
-from ccdc.molecule import Molecule, Coordinates
-from ccdc.protein import Protein
-from ccdc.utilities import PushDir
+
 from scipy import ndimage
 from skimage.morphology import ball
 from skimage.transform import resize
 # from hotspots.protoss import Protoss
 from tqdm import tqdm
+
+# Development note. We import the CCDC modules after 3rd part modules where possible as
+# we generally find that the ccdc package is less fussy about the underlying compiled
+# libraries used.
+#  
+
+from ccdc.cavity import Cavity
+from ccdc.io import MoleculeWriter, MoleculeReader
+from ccdc.molecule import Molecule, Coordinates
+from ccdc.protein import Protein
+from ccdc.utilities import PushDir
 
 from hotspots.atomic_hotspot_calculation import _AtomicHotspot
 from hotspots.grid_extension import Grid

--- a/hotspots/grid_extension.py
+++ b/hotspots/grid_extension.py
@@ -22,7 +22,7 @@ from __future__ import print_function, division
 import collections
 import operator
 import numpy as np
-from ccdc import utilities
+
 from hotspots.hs_utilities import Helper
 from scipy import ndimage
 from scipy.spatial import distance
@@ -30,7 +30,7 @@ from skimage import feature
 from skimage.morphology import ball
 from os.path import join, basename
 from scipy.stats import norm
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 import pickle
 from functools import reduce
 
@@ -40,6 +40,8 @@ try:
     from hdbscan import HDBSCAN
 except ImportError:
     print('HDBSCAN module not installed. _GridEnsemble clustering not available.')
+
+from ccdc import utilities
 
 Coordinates = collections.namedtuple('Coordinates', ['x', 'y', 'z'])
 

--- a/hotspots/hs_ensembles.py
+++ b/hotspots/hs_ensembles.py
@@ -1,9 +1,11 @@
 #from __future__ import print_function, division
+import numpy as np
+
 from hotspots.result import Results
 from hotspots.hs_utilities import Helper
 from hotspots.grid_extension import Grid, _GridEnsemble
 from ccdc.protein import Protein
-import numpy as np
+
 
 
 class EnsembleResult(Helper):

--- a/hotspots/hs_pharmacophore.py
+++ b/hotspots/hs_pharmacophore.py
@@ -36,16 +36,6 @@ import tempfile
 from os.path import basename, splitext, join, dirname
 
 import numpy as np
-from ccdc import io
-from ccdc.descriptors import GeometricDescriptors
-from ccdc.molecule import Atom, Molecule, Coordinates
-from ccdc.pharmacophore import Pharmacophore
-from ccdc.protein import Protein
-
-from hotspots.grid_extension import Grid, Coordinates
-from hotspots.hs_utilities import Helper
-from hotspots.template_strings import pymol_arrow, pymol_imports, pymol_protein, crossminer_features, pymol_labels
-from hotspots.wrapper_pdb import Query, PDB, PDBResult
 
 from rdkit import Chem, DataStructs
 from rdkit.Chem import MACCSkeys, AllChem
@@ -57,6 +47,23 @@ import pandas as pd
 from sklearn.manifold import TSNE
 import matplotlib.pyplot as plt
 import hdbscan
+
+# Development note. We import the CCDC modules after 3rd part modules where possible as
+# we generally find that the ccdc package is less fussy about the underlying compiled
+# libraries used.
+#  
+
+from ccdc import io
+from ccdc.descriptors import GeometricDescriptors
+from ccdc.molecule import Atom, Molecule, Coordinates
+from ccdc.pharmacophore import Pharmacophore
+from ccdc.protein import Protein
+
+from hotspots.grid_extension import Grid, Coordinates
+from hotspots.hs_utilities import Helper
+from hotspots.template_strings import pymol_arrow, pymol_imports, pymol_protein, crossminer_features, pymol_labels
+from hotspots.wrapper_pdb import Query, PDB, PDBResult
+
 
 
 def tanimoto_dist(a, b):

--- a/hotspots/hs_utilities.py
+++ b/hotspots/hs_utilities.py
@@ -17,7 +17,14 @@ from os.path import exists, join, abspath
 
 # import matplotlib as mpl
 # mpl.use('TkAgg')
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import sys
+    sys.stderr.write("Matplotlib import failed: probably due to incompatibilities. Plotting utilities will not work")
+    plt = None
+
 
 import numpy as np
 

--- a/hotspots/protein_extension.py
+++ b/hotspots/protein_extension.py
@@ -1,7 +1,7 @@
-from ccdc import protein
 import numpy as np
 from scipy.spatial import distance
 
+from ccdc import protein
 
 def centroid(arr):
     length = arr.shape[0]

--- a/hotspots/wrapper_pdb.py
+++ b/hotspots/wrapper_pdb.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 if sys.version_info.major == 2:
     from urllib2 import Request as request
     from urllib2 import urlopen as urlopen
+    
 
 else:
     from urllib.request import Request as request
@@ -382,19 +383,21 @@ class PDBResult(object):
         :param identifier:
         """
         self.identifier = identifier
-
-        self._ligands = self.get_ligands()
+        self._ligands = None 
 
     def _raw_properties(self, info_type='ligand'):
         """
 
         :return:
         """
+        raise NotImplementedError("TODO: The PDB wrapper code needs updating to use the modern RESTful API") 
+
         info_type_dict = {'describe_pdb': '/describePDB?structureId=',
                           'describe_mol': '/describeMol?structureId=',
                           'ligand': '/ligandInfo?structureId=',
                           'pfam': '/hmmer?structureId=',
                           'general': '/getEntityInfo?structureId='}
+
 
         url = request(base_url + info_type_dict[info_type] + self.identifier)
         return urlopen(url)
@@ -408,6 +411,9 @@ class PDBResult(object):
         :param field:
         :return:
         """
+        
+        raise NotImplementedError("TODO: The PDB wrapper code needs updating to use the modern RESTful API")
+        
         extension = "/customReport.xml?pdbids={}&customReportColumns={}&service=wsfile&format=xml".format(self.identifier, field)
         url = request(base_url + extension)
 
@@ -447,6 +453,9 @@ class PDBResult(object):
     @property
     def ligands(self):
         """"""
+        if self._ligands == None:
+            self._ligands = self.get_ligands()
+        
         return self._ligands
 
     def get_ligands(self):


### PR DESCRIPTION
I've made some minor changes to documentation (to solve something that tripped me up - namely creating the conda environment) and have slightly re-organized the code to avoid import conflicts if possible.

Finally I've removed the pymol dependency (commented out) as this makes things not work if you dont have pymol

 wrapper_pdb has been slightly reorganised so that PDBResult works when you are not using it for anything other than just downloading PDB files but throws a NotImplementedError when you try to use features that relied on the now defunct old PDB restful services which shut down on December 9th 2020.